### PR TITLE
Potential fix for code scanning alert no. 12: Prototype-polluting assignment

### DIFF
--- a/server/goalenv/Lib/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
+++ b/server/goalenv/Lib/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
@@ -16,6 +16,10 @@ self.addEventListener("message", async function (event) {
     return;
   } else if (event.data.getMore) {
     let connectionID = event.data.getMore;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     let { curOffset, value, reader, intBuffer, byteBuffer } =
       connections[connectionID];
     // if we still have some in buffer, then just send it back straight away
@@ -63,6 +67,10 @@ self.addEventListener("message", async function (event) {
   } else {
     // start fetch
     let connectionID = nextConnectionID;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     nextConnectionID += 1;
     const intBuffer = new Int32Array(event.data.buffer);
     const byteBuffer = new Uint8Array(event.data.buffer, 8);


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/goal-ith/security/code-scanning/12](https://github.com/ArmaanjeetSandhu/goal-ith/security/code-scanning/12)

To fix the problem, we need to ensure that the `connectionID` cannot be set to a value that would modify `Object.prototype`. This can be achieved by validating the `connectionID` before using it as a key in the `connections` object. We will reject any `connectionID` that is `__proto__`, `constructor`, or `prototype`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
