### PR TITLE
Potential fix for code scanning alert no. 10: Flask app is run in debug mode

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -374,4 +374,5 @@ def extract_nutrients(nutrients_data: List[Dict]) -> Dict[str, float]:
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))
-    app.run(host="0.0.0.0", port=port, debug=True)
+    debug_mode = os.environ.get("FLASK_DEBUG", "False").lower() in ["true", "1"]
+    app.run(host="0.0.0.0", port=port, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/goal-ith/security/code-scanning/10](https://github.com/ArmaanjeetSandhu/goal-ith/security/code-scanning/10)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production settings without changing the code.

1. Modify the `app.run` call to use an environment variable to determine whether to enable debug mode.
2. Update the code to read the environment variable and set the debug mode accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
