### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -28,11 +28,12 @@ mimetypes.add_type("video/mp4", ".mp4")
 @app.route("/", defaults={"path": ""})
 @app.route("/<path:path>")
 def serve(path):
-    if path != "" and os.path.exists(os.path.join(app.static_folder, path)):
+    normalized_path = os.path.normpath(os.path.join(app.static_folder, path))
+    if not normalized_path.startswith(app.static_folder):
+        return "Forbidden", 403
+    if path != "" and os.path.exists(normalized_path):
         if path.endswith(".mp4"):
-            return send_file(
-                os.path.join(app.static_folder, path), mimetype="video/mp4"
-            )
+            return send_file(normalized_path, mimetype="video/mp4")
         return send_from_directory(app.static_folder, path)
     else:
         return send_from_directory(app.static_folder, "index.html")


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/goal-ith/security/code-scanning/14](https://github.com/ArmaanjeetSandhu/goal-ith/security/code-scanning/14)

To fix the problem, we need to validate and normalize the `path` variable before using it to construct the file path. This can be done by using `os.path.normpath` to remove any ".." segments and then checking that the normalized path starts with the `app.static_folder` directory. This ensures that the resulting path is contained within the intended directory.

1. Normalize the `path` variable using `os.path.normpath`.
2. Check that the normalized path starts with the `app.static_folder` directory.
3. If the check fails, return a 403 Forbidden response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
